### PR TITLE
Issue found when trying Single Log-Out service

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -136,7 +136,11 @@ export default class Metadata implements MetadataInterface {
   public getSingleLogoutService(binding: string | undefined): string | object {
     if (isString(binding)) {
       const bindType = namespace.binding[binding];
-      const service = this.meta.singleLogoutService.find(obj => obj.binding === bindType);
+      let singleLogoutService = this.meta.singleLogoutService;
+      if (!(singleLogoutService instanceof Array)) {
+        singleLogoutService = [singleLogoutService];
+      }
+      const service = singleLogoutService.find(obj => obj.binding === bindType);
       if (service) {
         return service.location;
       }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -59,7 +59,9 @@ export default class Metadata implements MetadataInterface {
       {
         key: 'singleLogoutService',
         localPath: ['EntityDescriptor', '~SSODescriptor', 'SingleLogoutService'],
-        attributes: ['Binding', 'Location']
+        index: ['Binding'],
+        attributePath: [],
+        attributes: ['Location']
       },
       {
         key: 'nameIDFormat',
@@ -136,13 +138,9 @@ export default class Metadata implements MetadataInterface {
   public getSingleLogoutService(binding: string | undefined): string | object {
     if (isString(binding)) {
       const bindType = namespace.binding[binding];
-      let singleLogoutService = this.meta.singleLogoutService;
-      if (!(singleLogoutService instanceof Array)) {
-        singleLogoutService = [singleLogoutService];
-      }
-      const service = singleLogoutService.find(obj => obj.binding === bindType);
+      const service = this.meta.singleLogoutService[bindType];
       if (service) {
-        return service.location;
+        return service;
       }
     }
     return this.meta.singleLogoutService;

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -137,8 +137,8 @@ export default class Metadata implements MetadataInterface {
   */
   public getSingleLogoutService(binding: string | undefined): string | object {
     if (isString(binding)) {
-      const bindType = namespace.binding[binding];
-      const service = this.meta.singleLogoutService[bindType];
+      const bindName = namespace.binding[binding];
+      const service = this.meta.singleLogoutService[bindName];
       if (service) {
         return service;
       }


### PR DESCRIPTION
When `SingleLogoutService` only have one binding method in IdP metadata, `this.meta.singleLogoutService` is an object instead of an array, which will throw an exception `this.meta.singleLogoutService.find is not a function`.

These changes implemented in the latest version of the library.